### PR TITLE
Mimiked renaming of designator_integration into designator_integration_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(semrec)
 
-find_package(catkin REQUIRED COMPONENTS roscpp roslib rospack designator_integration designator_integration_msgs sensor_msgs cv_bridge interactive_markers visualization_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp roslib rospack designator_integration_cpp designator_integration_msgs sensor_msgs cv_bridge interactive_markers visualization_msgs)
 
 add_subdirectory(3rdparty)
 
@@ -18,7 +18,7 @@ endif()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES sr_plugin_ros sr_plugin_gazebo sr_plugin_console sr_plugin_experiment_context sr_plugin_interactive sr_plugin_symboliclog sr_plugin_supervisor sr_plugin_owlexporter sr_plugin_dotexporter
-  CATKIN_DEPENDS roscpp roslib designator_integration designator_integration_msgs sensor_msgs cv_bridge interactive_markers visualization_msgs
+  CATKIN_DEPENDS roscpp roslib designator_integration_cpp designator_integration_msgs sensor_msgs cv_bridge interactive_markers visualization_msgs
 )
 
 include_directories(

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   
   <build_depend>roslib</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>designator_integration</build_depend>
+  <build_depend>designator_integration_cpp</build_depend>
   <build_depend>designator_integration_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
@@ -28,7 +28,7 @@
   
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>designator_integration</run_depend>
+  <run_depend>designator_integration_cpp</run_depend>
   <run_depend>designator_integration_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>


### PR DESCRIPTION
@fairlight1337 This relates to https://github.com/code-iai/designator_integration/pull/3 and should be merged afterwards.