### PR TITLE
Added ROS-deps of 3 packages mentioned as debs in README.md

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,10 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>interactive_markers</build_depend>
   <build_depend>visualization_msgs</build_depend>
-  
+  <build_depend>autoconf</build_depend>
+  <build_depend>automake</build_depend>
+  <build_depend>libncurses-dev</build_depend>
+
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>designator_integration_cpp</run_depend>
@@ -34,5 +37,8 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>interactive_markers</run_depend>
   <run_depend>visualization_msgs</run_depend>
-  
+  <run_depend>autoconf</run_depend>
+  <run_depend>automake</run_depend>
+  <run_depend>libncurses-dev</run_depend>
+
 </package>


### PR DESCRIPTION
The three dependencies mentioned in the README.md are actually part of rosdep, and can be automatically installed through rosdep. To enable this, I added them in the package.xml. Is related to https://github.com/code-iai/semrec/issues/7